### PR TITLE
Adding support for draftjs in transcript editor

### DIFF
--- a/src/components/hmgm/TranscriptEditor.vue
+++ b/src/components/hmgm/TranscriptEditor.vue
@@ -72,12 +72,12 @@ export default {
   methods:{
     // Set data for editor
     setData(content, temporaryFile){
-      if(temporaryFile===true){  
+      if(temporaryFile===true || !this.transcriptType){  
         this.sttType = "draftjs";
         this.transcriptDataValue = JSON.parse(content);
       }
       else {
-        if(!this.transcriptType || this.transcriptType==1){
+        if(this.transcriptType==1){
           this.sttType = "amazontranscribe";
           this.transcriptDataValue = JSON.parse(content);
         }


### PR DESCRIPTION
Adding support for AMP speech to text format in the transcript editor.  If the URL for amppd-ui does not contain a transcript type, it will use the draftjs format. Otherwise Transcript type of 1 is AWS and Transcript Type of 2 is Kaldi.  