### PR TITLE
AMP-864 workflow search bug

### DIFF
--- a/src/components/workflow/SelectFiles.vue
+++ b/src/components/workflow/SelectFiles.vue
@@ -2,9 +2,9 @@
 <div class="col-lg-7">
    <h1>Workflow Submissions</h1>
    <h2>Select files</h2>
-   <form class="marg-t-3 filter-form">
+   <form class="marg-t-3 filter-form" v-on:submit.prevent @keyup.enter.prevent="searchFiles()">
       <div class="container-fluid">
-         <div class="row">  
+         <div class="row">
             <div class="col-xl-6 col-md-12">
                <div id="limiter">
                   <strong>Limit results to </strong>
@@ -107,7 +107,7 @@
             </div>
          </div>
       </div>
-      <div v-else>  
+      <div v-else>
          No Results
       </div>
    </div>
@@ -169,7 +169,7 @@ export default {
          if(self.searchWord.length >0){
             self.searchedItems = await self.workflowService.searchFiles(this.searchWord, media_type);
             if(self.searchedItems.rows!=null)
-            {    
+            {
                self.searchResults = true;
             }
             else
@@ -223,9 +223,9 @@ export default {
          }).catch(e => {
             console.log(e);
             this.workflowSubmission.showBundleError = true;
-         }); 
+         });
       }
-    
+
    },
    watch:{
       searchAudio: function(){
@@ -249,8 +249,8 @@ export default {
   .form-errors {
     color: red;
     margin: 0%!important;
-    font-size: 0.9rem; 
-    padding-left:3px; 
+    font-size: 0.9rem;
+    padding-left:3px;
     width: inherit;
   }
   .item-name{

--- a/src/components/workflow/SelectFiles.vue
+++ b/src/components/workflow/SelectFiles.vue
@@ -2,7 +2,7 @@
 <div class="col-lg-7">
    <h1>Workflow Submissions</h1>
    <h2>Select files</h2>
-   <form class="marg-t-3 filter-form" v-on:submit.prevent @keyup.enter.prevent="searchFiles()">
+   <form class="marg-t-3 filter-form" v-on:submit.prevent @keyup.enter="searchFiles()">
       <div class="container-fluid">
          <div class="row">
             <div class="col-xl-6 col-md-12">
@@ -28,7 +28,7 @@
             </div>
          </div>
       </div>
-      <div class="form-group ">
+      <div class="form-group">
          <div class="container-fluid">
             <div class="row">
                <div class="col-12">

--- a/src/components/workflow/SelectFiles.vue
+++ b/src/components/workflow/SelectFiles.vue
@@ -37,7 +37,7 @@
                      <label class="form-errors" v-if="errors.search_error.length">{{errors.search_error}}</label>
                      <input type="text" class="form-control" id="exampleFormControlInput100" placeholder="Search" v-model="searchWord">
                      <div class="input-group-append">
-                        <button class="btn" v-on:click="searchFiles()">
+                        <button class="btn" type="button" v-on:click="searchFiles()">
                            <svg data-v-6b33b2c4="" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" class="svg-search"><title data-v-6b33b2c4="">search</title><path data-v-6b33b2c4="" d="M47.3 43.4c0 0.9-0.3 1.7-1 2.4 -0.7 0.7-1.5 1-2.4 1 -0.9 0-1.7-0.3-2.4-1l-9-9c-3.1 2.2-6.6 3.3-10.5 3.3 -2.5 0-4.9-0.5-7.2-1.5 -2.3-1-4.2-2.3-5.9-3.9s-3-3.6-3.9-5.9c-1-2.3-1.5-4.7-1.5-7.2 0-2.5 0.5-4.9 1.5-7.2 1-2.3 2.3-4.2 3.9-5.9s3.6-3 5.9-3.9c2.3-1 4.7-1.5 7.2-1.5 2.5 0 4.9 0.5 7.2 1.5 2.3 1 4.2 2.3 5.9 3.9s3 3.6 3.9 5.9c1 2.3 1.5 4.7 1.5 7.2 0 3.8-1.1 7.3-3.3 10.5l9 9C47 41.7 47.3 42.5 47.3 43.4zM30.4 29.9c2.3-2.3 3.4-5.1 3.4-8.3 0-3.2-1.1-6-3.4-8.3 -2.3-2.3-5.1-3.4-8.3-3.4 -3.2 0-6 1.1-8.3 3.4 -2.3 2.3-3.4 5.1-3.4 8.3 0 3.2 1.1 6 3.4 8.3 2.3 2.3 5.1 3.4 8.3 3.4C25.4 33.4 28.1 32.2 30.4 29.9z"></path></svg>
                            Search
                         </button>

--- a/src/components/workflow/SelectFiles.vue
+++ b/src/components/workflow/SelectFiles.vue
@@ -2,7 +2,7 @@
 <div class="col-lg-7">
    <h1>Workflow Submissions</h1>
    <h2>Select files</h2>
-   <form class="marg-t-3 filter-form" v-on:submit.prevent @keyup.enter="searchFiles()">
+   <form class="marg-t-3 filter-form" v-on:submit.prevent v-on:keyup.enter="searchFiles()">
       <div class="container-fluid">
          <div class="row">
             <div class="col-xl-6 col-md-12">


### PR DESCRIPTION
The issue card mentions one bug but as it turns out, there were actually two bugs. The first one, pressing the enter key, is referenced in the card [AMP-864](https://bugs.dlib.indiana.edu/browse/AMP-864). The second bug, not mentioned in the card, was that clicking the search button would also refresh the page on first click and then execute the search on second click.

Enter key fix: add `v-on:submit.prevent` and `v-on:keyup.enter="searchFiles()` on the form element in order to 1. prevent default form submission behavior and 2. call `searchFiles()` when enter key is released.

Search button fix: add `type="button"` on the search button to prevent default form submission behavior.