### PR TITLE
Making sure only complete items are returned on deliverables page

### DIFF
--- a/src/components/deliverables/Deliverables.vue
+++ b/src/components/deliverables/Deliverables.vue
@@ -184,7 +184,7 @@ export default {
             filterByItems:[],
             filterByFiles:[],
             filterBySteps:[],
-            filterByStatuses:[],
+            filterByStatuses:['COMPLETE'],
             filterBySearchTerm:[],
             filterByFinal: false
           },


### PR DESCRIPTION
I was unable to replicate the suggested error, but did notice that we were not filtering on complete items in the deliverables page.  This PR is to address that.  