### PR TITLE
AMP-1084 Handling null values

### DIFF
--- a/src/components/shared/TypeAhead.vue
+++ b/src/components/shared/TypeAhead.vue
@@ -91,12 +91,12 @@ export default {
             let self = this;
             if(self.filterType=="starts"){
                 return self.items.filter((item) => {
-                    return item.toLowerCase().startsWith(self.query.toLowerCase());
+                    return item && item.toLowerCase().startsWith(self.query.toLowerCase());
                     });
             }
             else if(self.filterType=="contains") {
                 return self.items.filter((item) => {
-                    return item.toLowerCase().includes(self.query.toLowerCase());
+                    return item && item.toLowerCase().includes(self.query.toLowerCase());
                     });
             }
         },


### PR DESCRIPTION
The && operand takes advantage of short-circuiting and stops as soon as falsy value or null value encountered. it won't evaluate the next expression. so we can avoid the calling toLowerCase() method on Null value. 



