### PR TITLE
AMP-2680:Add unit selection to batch ingest page

### DIFF
--- a/src/components/entity/EntityList.vue
+++ b/src/components/entity/EntityList.vue
@@ -1164,13 +1164,13 @@ export default {
       //Checking Access Control
       self.accessControlService.checkAccessControl(this);
 
-      //BATCH INGEST: Enable batch ingest nav
-      let batchIngestHtml = document.getElementById("/batch/ingest");
-      if (batchIngestHtml) {
-        batchIngestHtml = batchIngestHtml.childNodes[0];
-        batchIngestHtml.ariaDisabled = null;
-        batchIngestHtml.classList.remove("disabled");
-      }
+      // //BATCH INGEST: Enable batch ingest nav
+      // let batchIngestHtml = document.getElementById("/batch/ingest");
+      // if (batchIngestHtml) {
+      //   batchIngestHtml = batchIngestHtml.childNodes[0];
+      //   batchIngestHtml.ariaDisabled = null;
+      //   batchIngestHtml.classList.remove("disabled");
+      // }
     },
     async toggleCollectionActive(collection) {
       collection.active = !collection.active;
@@ -1468,20 +1468,20 @@ export default {
     if (uEntity && uEntity.currentUnit)
       self.accessControlService.checkAccessControl(this);
 
-    let batchIngestHtml = document.getElementById("/batch/ingest");
-    if (batchIngestHtml) {
-      if (!uEntity || (uEntity && !uEntity.currentUnit)) {
-        //BATCH INGEST: Disable batch ingest nav
-        batchIngestHtml = batchIngestHtml.childNodes[0];
-        batchIngestHtml.ariaDisabled = "true";
-        batchIngestHtml.classList.add("disabled");
-      } else {
-        //BATCH INGEST: Enable batch ingest nav
-        batchIngestHtml = batchIngestHtml.childNodes[0];
-        batchIngestHtml.ariaDisabled = null;
-        batchIngestHtml.classList.remove("disabled");
-      }
-    }
+    // let batchIngestHtml = document.getElementById("/batch/ingest");
+    // if (batchIngestHtml) {
+    //   if (!uEntity || (uEntity && !uEntity.currentUnit)) {
+    //     //BATCH INGEST: Disable batch ingest nav
+    //     batchIngestHtml = batchIngestHtml.childNodes[0];
+    //     batchIngestHtml.ariaDisabled = "true";
+    //     batchIngestHtml.classList.add("disabled");
+    //   } else {
+    //     //BATCH INGEST: Enable batch ingest nav
+    //     batchIngestHtml = batchIngestHtml.childNodes[0];
+    //     batchIngestHtml.ariaDisabled = null;
+    //     batchIngestHtml.classList.remove("disabled");
+    //   }
+    // }
 
     if (!uEntity) {
       self.unitEntity = { unitList: [], currentUnit: "" };

--- a/src/components/home/index.vue
+++ b/src/components/home/index.vue
@@ -110,21 +110,21 @@ export default {
   mounted() {
     this.networkCalls();
 
-    const uEntity = JSON.parse(sessionStorage.getItem("unitEntity"));
-    let batchIngestHtml = document.getElementById("/batch/ingest");
-    if (batchIngestHtml) {
-      if (!uEntity || (uEntity && !uEntity.currentUnit)) {
-        //BATCH INGEST: Disable batch ingest nav
-        batchIngestHtml = batchIngestHtml.childNodes[0];
-        batchIngestHtml.ariaDisabled = "true";
-        batchIngestHtml.classList.add("disabled");
-      } else {
-        //BATCH INGEST: Enable batch ingest nav
-        batchIngestHtml = batchIngestHtml.childNodes[0];
-        batchIngestHtml.ariaDisabled = null;
-        batchIngestHtml.classList.remove("disabled");
-      }
-    }
+    // const uEntity = JSON.parse(sessionStorage.getItem("unitEntity"));
+    // let batchIngestHtml = document.getElementById("/batch/ingest");
+    // if (batchIngestHtml) {
+    //   if (!uEntity || (uEntity && !uEntity.currentUnit)) {
+    //     //BATCH INGEST: Disable batch ingest nav
+    //     batchIngestHtml = batchIngestHtml.childNodes[0];
+    //     batchIngestHtml.ariaDisabled = "true";
+    //     batchIngestHtml.classList.add("disabled");
+    //   } else {
+    //     //BATCH INGEST: Enable batch ingest nav
+    //     batchIngestHtml = batchIngestHtml.childNodes[0];
+    //     batchIngestHtml.ariaDisabled = null;
+    //     batchIngestHtml.classList.remove("disabled");
+    //   }
+    // }
   },
 };
 </script>

--- a/src/components/shared/Search.vue
+++ b/src/components/shared/Search.vue
@@ -1050,15 +1050,15 @@ export default {
                       if (uEntity && uEntity.currentUnit)
                         self.accessControlService.checkAccessControl(self);
 
-                      //BATCH INGEST: Enable batch ingest nav
-                      let batchIngestHtml = document.getElementById(
-                        "/batch/ingest"
-                      );
-                      if (batchIngestHtml) {
-                        batchIngestHtml = batchIngestHtml.childNodes[0];
-                        batchIngestHtml.ariaDisabled = null;
-                        batchIngestHtml.classList.remove("disabled");
-                      }
+                      // //BATCH INGEST: Enable batch ingest nav
+                      // let batchIngestHtml = document.getElementById(
+                      //   "/batch/ingest"
+                      // );
+                      // if (batchIngestHtml) {
+                      //   batchIngestHtml = batchIngestHtml.childNodes[0];
+                      //   batchIngestHtml.ariaDisabled = null;
+                      //   batchIngestHtml.classList.remove("disabled");
+                      // }
                     });
 
                   const res = JSON.parse(JSON.stringify(response));

--- a/src/service/account-service.js
+++ b/src/service/account-service.js
@@ -112,6 +112,7 @@ function logout() {
   localStorage.removeItem('currentUser');
   sessionStorage.removeItem('userValues');
   sessionStorage.removeItem('unitEntity');
+  sessionStorage.removeItem('batchUnits');
   this.currentUser = null;
 }
 


### PR DESCRIPTION
This PR implements the ability to select units on the batch ingest page. The unit selection on this page does not depend on the unit selected on the content navigation or any other page. The batch ingest panel stays disabled until a unit is selected on the page as below;

![Screenshot from 2023-06-26 15-32-12](https://github.com/AudiovisualMetadataPlatform/amppd-ui/assets/1331659/94a609f6-c488-46da-be86-81175e0e5f06)
![Screenshot from 2023-06-26 15-32-18](https://github.com/AudiovisualMetadataPlatform/amppd-ui/assets/1331659/0a18aba4-d094-4394-8dd0-31ba3964ef82)
