### PR TITLE
Update dashboard table when filters are removed

### DIFF
--- a/src/components/dashboard/Dashboard.vue
+++ b/src/components/dashboard/Dashboard.vue
@@ -1,55 +1,31 @@
 <template>
   <div class="collections w-100 px-0">
-    <div
-      class="container-fluid"
-      :class="{
-        'p-0': parent === 'NewTest' || parent === 'TestResults',
-      }"
-    >
+    <div class="container-fluid"
+      :class="{ 'p-0': parent === 'NewTest' || parent === 'TestResults' }">
       <div class="row">
-        <div
-          class="col-12"
-          :class="{
-            'bg-light-gray-1': parent !== 'NewTest' && parent !== 'TestResults',
-          }"
-        >
+        <div class="col-12"
+          :class="{ 'bg-light-gray-1': parent !== 'NewTest' && parent !== 'TestResults' }">
           <main class="m-0">
             <div class="pad-all-3">
-              <div
-                class="card"
-                :class="{
-                  'mb-0': parent === 'NewTest' || parent === 'TestResults',
-                }"
-              >
+              <div class="card"
+                :class="{ 'mb-0': parent === 'NewTest' || parent === 'TestResults' }">
                 <div class="card-body px-2">
-                  <h1
-                    v-if="parent !== 'NewTest' && parent !== 'TestResults'"
-                    class="card-title pb-3"
-                  >
+                  <h1 v-if="parent !== 'NewTest' && parent !== 'TestResults'" class="card-title pb-3">
                     AMP Dashboard
                   </h1>
                   <div v-if="filterCount > 0">
                     <div class="d-flex flex-wrap px-0">
-                      <div class="col-sm-2 fw-bold">
-                        CURRENTLY FILTERED BY
-                      </div>
+                      <div class="col-sm-2 fw-bold">CURRENTLY FILTERED BY</div>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-if="
-                          workflowDashboard.searchQuery.filterByDates.length > 0
-                        "
-                      >
+                        v-if="workflowDashboard.searchQuery.filterByDates.length > 0">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeDateFilter(index)"></span>
                           <div class="d-flex flex-column">
-                            <label class="fw-bold col-auto"
-                              >{{
-                                parent === "TestResults"
-                                  ? "Output date"
-                                  : "Date"
-                              }}
-                              range</label
-                            >
+                            <label class="fw-bold col-auto">
+                              {{ parent === "TestResults" ? "Output date" : "Date" }}
+                              range
+                            </label>
                             <label>{{
                                 workflowDashboard.searchQuery.filterByDates[0].getMonth() +
                                   1
@@ -73,11 +49,7 @@
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-if="
-                          workflowDashboard.searchQuery.filterByTestDates
-                            .length > 0
-                        "
-                      >
+                        v-if="workflowDashboard.searchQuery.filterByTestDates.length > 0">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeTestDateFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -98,19 +70,16 @@
                                 workflowDashboard.searchQuery.filterByTestDates[1].getDate()
                               }}/{{
                                 workflowDashboard.searchQuery.filterByTestDates[1].getFullYear()
-                              }}</label
-                            >
+                              }}</label>
                           </div>
                         </div>
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(submitter, index) in workflowDashboard
-                          .searchQuery.filterBySubmitters"
+                        v-for="(submitter, index) in workflowDashboard.searchQuery.filterBySubmitters"
                         v-bind:submitter="submitter"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeSubmitterFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -124,8 +93,7 @@
                         v-for="(unit, index) in selectedFilters.units"
                         v-bind:workflow="unit.unitName"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeUnitFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -136,12 +104,10 @@
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(collection,
-                        index) in selectedFilters.collections"
+                        v-for="(collection, index) in selectedFilters.collections"
                         v-bind:workflow="collection.collectionName"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeCollectionFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -152,12 +118,10 @@
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(externalId, index) in workflowDashboard
-                          .searchQuery.filterByExternalIds"
+                        v-for="(externalId, index) in workflowDashboard.searchQuery.filterByExternalIds"
                         v-bind:externalId="externalId"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeExternalIdFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -171,8 +135,7 @@
                         v-for="(item, index) in selectedFilters.items"
                         v-bind:item="item.itemName"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeItemFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -186,8 +149,7 @@
                         v-for="(file, index) in selectedFilters.primaryfiles"
                         v-bind:file="file.primaryfileName"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeFileFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -198,12 +160,10 @@
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(workflow, index) in workflowDashboard
-                          .searchQuery.filterByWorkflows"
+                        v-for="(workflow, index) in workflowDashboard.searchQuery.filterByWorkflows"
                         v-bind:workflow="workflow"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeWorkflowFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -214,12 +174,10 @@
                       </button>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(step, index) in workflowDashboard.searchQuery
-                          .filterBySteps"
+                        v-for="(step, index) in workflowDashboard.searchQuery.filterBySteps"
                         v-bind:step="step"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
                           <span v-html="closeIconSvg" class="col-auto" @click="removeStepFilter(index)"></span>
                           <div class="d-flex flex-column">
@@ -231,12 +189,10 @@
                       <span v-if="parent !== 'NewTest'">
                         <button
                           class="btn btn-outline col-sm-2 selected-filter-button"
-                          v-for="(output, index) in workflowDashboard
-                            .searchQuery.filterByOutputs"
+                          v-for="(output, index) in workflowDashboard.searchQuery.filterByOutputs"
                           v-bind:output="output"
                           v-bind:index="index"
-                          v-bind:key="index"
-                        >
+                          v-bind:key="index">
                           <div class="d-flex flex-row justify-content-between">
                             <span v-html="closeIconSvg" class="col-auto" @click="removeOutputFilter(index)"></span>
                             <div class="d-flex flex-column">
@@ -246,17 +202,13 @@
                           </div>
                         </button>
                       </span>
-                      <span
-                        v-if="parent !== 'NewTest' && parent !== 'TestResults'"
-                      >
+                      <span v-if="parent !== 'NewTest' && parent !== 'TestResults'">
                         <button
                           class="btn btn-outline col-sm-2 selected-filter-button"
-                          v-for="(status, index) in workflowDashboard
-                            .searchQuery.filterByStatuses"
+                          v-for="(status, index) in workflowDashboard.searchQuery.filterByStatuses"
                           v-bind:status="status"
                           v-bind:index="index"
-                          v-bind:key="index"
-                        >
+                          v-bind:key="index">
                           <div class="d-flex flex-row justify-content-between">
                             <span v-html="closeIconSvg" class="col-auto" @click="removeStatusFilter(index)"></span>
                             <div class="d-flex flex-column">
@@ -268,14 +220,12 @@
                       </span>
                       <button
                         class="btn btn-outline col-sm-2 selected-filter-button"
-                        v-for="(searchTerm, index) in workflowDashboard
-                          .searchQuery.filterBySearchTerms"
+                        v-for="(searchTerm, index) in workflowDashboard.searchQuery.filterBySearchTerms"
                         v-bind:searchTerm="searchTerm"
                         v-bind:index="index"
-                        v-bind:key="index"
-                      >
+                        v-bind:key="index">
                         <div class="d-flex flex-row justify-content-between">
-                          <span v-html="closeIconSvg" class="col-auto" @click="removeSearchFilter(index)"></span>
+                          <span v-html="closeIconSvg" class="col-auto" @click="removeSearchFilter()"></span>
                           <div class="d-flex flex-column">
                             <label class="fw-bold col-auto">Search Term</label>
                             <label>{{ searchTerm }}</label>
@@ -298,112 +248,52 @@
                       :parent="parent"
                       v-if="parent === 'TestResults'"
                       label="Test Date"
-                      @displayChanged="
-                        changeDisplayedFilter(
-                          workflowDashboard.filtersEnabled.dateFilter
-                        )
-                      "
+                      @displayChanged="changeDisplayedFilter(workflowDashboard.filtersEnabled.dateFilter)"
                     />
                     <DateFilter
                       :parent="parent"
-                      @displayChanged="
-                        changeDisplayedFilter(
-                          workflowDashboard.filtersEnabled.dateFilter
-                        )
-                      "
+                      @displayChanged="changeDisplayedFilter(workflowDashboard.filtersEnabled.dateFilter)"
                     />
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('submitter')"
-                      >Submitter</b-button
-                    >                        
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('unit')"
-                      >Unit</b-button
-                    >
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('collection')"
-                      >Collection</b-button
-                    >
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('item')"
-                      >Item</b-button
-                    >
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('primaryfile')"
-                      >Content File</b-button
-                    >
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('workflow')"
-                      >Workflow</b-button
-                    >
-                    <b-button
-                      v-if="parent !== 'NewTest'"
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('output')"
-                      >Output</b-button
-                    >                        
-                    <b-button
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('step')"
-                      >Step</b-button
-                    >
-                    <b-button
-                      v-if="parent !== 'NewTest' && parent !== 'TestResults'"
-                      class="btn btn-info dropdown"
-                      v-b-modal.modal-lg
-                      @click="onOpenModal('status')"
-                      >Status</b-button
-                    >
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('submitter')">Submitter</b-button>                        
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('unit')">Unit</b-button>
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('collection')">Collection</b-button>
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('item')">Item</b-button>
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('primaryfile')">Content File</b-button>
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('workflow')">Workflow</b-button>
+                    <b-button 
+                      v-if="parent !== 'NewTest'" 
+                      class="btn btn-info dropdown" 
+                      v-b-modal.modal-lg @click="onOpenModal('output')">
+                      Output
+                    </b-button>                        
+                    <b-button class="btn btn-info dropdown" v-b-modal.modal-lg @click="onOpenModal('step')">Step</b-button>
+                    <b-button 
+                      v-if="parent !== 'NewTest' && parent !== 'TestResults'" 
+                      class="btn btn-info dropdown" 
+                      v-b-modal.modal-lg @click="onOpenModal('status')">
+                      Status
+                    </b-button>
                     <search-filter
                       v-if="parent !== 'Deliverables'"
                       :parent="parent"
-                      class="px-2 my-1"
-                    />
-                    <span 
-                      v-if="parent !== 'NewTest' && parent !== 'TestResults'"
-                      class="px-2 my-2"
-                    >
-                      <span class="txt-v px-1 py-2">
-                        Show Relevant Results Only
-                      </span>
+                      class="px-2 my-1" />
+                    <span  v-if="parent !== 'NewTest' && parent !== 'TestResults'" class="px-2 my-2">
+                      <span class="txt-v px-1 py-2">Show Relevant Results Only</span>
                       <label class="switch my-0" title="Relevant Result">
                         <span class="visually-hidden">Relevant Result</span>
-                        <input
-                          type="checkbox"
-                          v-model="workflowDashboard.searchQuery.filterByRelevant"
-                        />
+                        <input type="checkbox" v-model="workflowDashboard.searchQuery.filterByRelevant" />
                         <span class="slider round"></span>
                       </label>
                     </span>
                     <span
-                      v-if="
-                        parent !== 'NewTest' &&
-                          parent !== 'TestResults' &&
-                          parent !== 'Deliverables'
-                        "
-                        class="ms-auto px-2 my-2"
-                      >
+                      v-if="parent !== 'NewTest' && parent !== 'TestResults' && parent !== 'Deliverables'"
+                      class="ms-auto px-2 my-2">
                       <input
                         id="export-results"
                         type="button"
                         class="btn btn-outline-primary btn-sm"
                         v-on:click="exportResults"
-                        value="Export to CSV"
-                      />
+                        value="Export to CSV" />
                     </span>
                   </div>
 
@@ -412,14 +302,12 @@
                     :columns="columns"
                     :parent="parent"
                     :workflowResultType="workflowResultType"
-                    :workflowResultOutput="workflowResultOutput"
-                  >
+                    :workflowResultOutput="workflowResultOutput">
                     <template #show-hide-columns>
                       <div
                         v-if="parent !== 'NewTest' && parent !== 'Deliverables'"
                         id="btn-show-hide"
-                        class="dropdown mb-2"
-                      >
+                        class="dropdown mb-2">
                         <b-dropdown id="dropdown-form" auto-close="outside">
                             <template #button-content>
                               <span>Show/Hide Columns</span>
@@ -449,8 +337,8 @@
                                 :checked="column"
                                 v-model="columns"
                                 @change="onChange($event.target, column)"
-                                class="mb-3 form-check"
-                                >{{ column.label }}
+                                class="mb-3 form-check">
+                                {{ column.label }}
                               </b-form-checkbox>
                             </b-dropdown-form>
                         </b-dropdown>
@@ -624,230 +512,51 @@ export default {
     },
     removeDateFilter() {
       this.workflowDashboard.searchQuery.filterByDates = [];
-      console.log(
-        "current date filter is:" +
-          this.workflowDashboard.searchQuery.filterByDates
-      );
     },
     removeTestDateFilter() {
       this.workflowDashboard.searchQuery.filterByTestDates = [];
-      console.log(
-        "current date filter is:" +
-          this.workflowDashboard.searchQuery.filterByTestDates
-      );
     },
     removeSubmitterFilter(index) {
-      let indx;
-      this.selectedFilters["submitters"].map((el, i) => {
-        if (
-          el.submitterName ===
-          this.workflowDashboard.searchQuery.filterBySubmitters[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["submitters"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterBySubmitters.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected submitters are:" +
-          this.workflowDashboard.searchQuery.filterBySubmitters +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["submitters"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterBySubmitters = this.selectedFilters['submitters'].map((el) => el.submitterName);
     },
     removeCollectionFilter(index) {
-      let indx;
-      this.selectedFilters["collections"].map((el, i) => {
-        if (
-          el.collectionId ===
-          this.workflowDashboard.searchQuery.filterByCollections[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["collections"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByCollections.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected search terms are:" +
-          this.workflowDashboard.searchQuery.filterByCollections +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["collections"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByCollections = this.selectedFilters['collections'].map((el) => el.collectionId);
     },
     removeExternalIdFilter(index) {
-      var removed = this.workflowDashboard.searchQuery.filterByExternalIds.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected externalIds are:" +
-          this.workflowDashboard.searchQuery.filterByExternalIds +
-          " and removed element is:" +
-          removed
-      );
+      this.workflowDashboard.searchQuery.filterByExternalIds = []
     },
     removeItemFilter(index) {
-      let indx;
-      this.selectedFilters["items"].map((el, i) => {
-        if (
-          el.itemId === this.workflowDashboard.searchQuery.filterByItems[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["items"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByItems.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected items are:" +
-          this.workflowDashboard.searchQuery.filterByItems +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["items"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByItems = this.selectedFilters['items'].map((el) => el.itemId);
     },
     removeFileFilter(index) {
-      let indx;
-      this.selectedFilters["primaryfiles"].map((el, i) => {
-        if (
-          el.primaryfileId ===
-          this.workflowDashboard.searchQuery.filterByFiles[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["primaryfiles"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByFiles.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected files are:" +
-          this.workflowDashboard.searchQuery.filterByFiles +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["primaryfiles"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByFiles = this.selectedFilters['primaryfiles'].map((el) => el.primaryfileId);
     },
     removeWorkflowFilter(index) {
-      let indx;
-      this.selectedFilters["workflows"].map((el, i) => {
-        if (
-          el.workflowName ===
-          this.workflowDashboard.searchQuery.filterByWorkflows[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["workflows"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByWorkflows.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected workflows are:" +
-          this.workflowDashboard.searchQuery.filterByWorkflows +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["workflows"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByWorkflows = this.selectedFilters['workflows'].map((el) => el.workflowName);
     },
     removeStepFilter(index) {
-      let indx;
-      this.selectedFilters["steps"].map((el, i) => {
-        if (
-          el.stepName ===
-          this.workflowDashboard.searchQuery.filterBySteps[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["steps"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterBySteps.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected steps are:" +
-          this.workflowDashboard.searchQuery.filterBySteps +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["steps"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterBySteps = this.selectedFilters['steps'].map((el) => el.stepName);
     },
     removeOutputFilter(index) {
-      let indx;
-      this.selectedFilters["outputs"].map((el, i) => {
-        if (
-          el.outputName ===
-          this.workflowDashboard.searchQuery.filterByOutputs[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["outputs"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByOutputs.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected outputs are:" +
-          this.workflowDashboard.searchQuery.filterByOutputs +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["outputs"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByOutputs = this.selectedFilters['outputs'].map((el) => el.outputName);
     },
     removeStatusFilter(index) {
-      let indx;
-      this.selectedFilters["statuses"].map((el, i) => {
-        console.log(this.selectedFilters["statuses"]);
-        console.log(this.workflowDashboard.searchQuery.filterByStatuses[index]);
-        if (
-          el.statusName ===
-          this.workflowDashboard.searchQuery.filterByStatuses[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["statuses"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByStatuses.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected statuses are:" +
-          this.workflowDashboard.searchQuery.filterByStatuses +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["statuses"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByStatuses = this.selectedFilters['statuses'].map((el) => el.statusName);
     },
-    removeSearchFilter(index) {
-      var removed = this.workflowDashboard.searchQuery.filterBySearchTerms.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected search terms are:" +
-          this.workflowDashboard.searchQuery.filterBySearchTerms +
-          " and removed element is:" +
-          removed
-      );
+    removeSearchFilter() {
+      this.workflowDashboard.searchQuery.filterBySearchTerms = []
     },
     removeUnitFilter(index) {
-      let indx;
-      this.selectedFilters["units"].map((el, i) => {
-        if (
-          el.unitId === this.workflowDashboard.searchQuery.filterByUnits[index]
-        )
-          indx = i;
-      });
-      this.selectedFilters["units"].splice(indx, 1);
-      var removed = this.workflowDashboard.searchQuery.filterByUnits.splice(
-        index,
-        1
-      );
-      console.log(
-        "selected outputs are:" +
-          this.workflowDashboard.searchQuery.filterByUnits +
-          " and removed element is:" +
-          removed
-      );
+      this.selectedFilters["units"].splice(index, 1);
+      this.workflowDashboard.searchQuery.filterByUnits = this.selectedFilters['units'].map((el) => el.unitId);
     },
     onOpenModal(value) {
       let self = this;

--- a/src/components/dashboard/DashboardTable.vue
+++ b/src/components/dashboard/DashboardTable.vue
@@ -12,8 +12,7 @@
             @change="
               refreshData();
               updateUserValues();
-            "
-          >
+            ">
             <option value="10">10</option>
             <option value="25">25</option>
             <option value="50">50</option>
@@ -104,8 +103,8 @@
               <a v-if="canAccessLink(rec, false) && outputReady(rec)"
                 @click="workflowResultService.getSymlinkContent(rec, true, parent, $event)"                
                 target="_blank"
-                class="complete-output"
-                >{{ rec.outputName }}
+                class="complete-output">
+                {{ rec.outputName }}
               </a>
               <a v-else-if="canAccessLink(rec, false)"
                 role="link" aria-disabled="true">{{ rec.outputName }}
@@ -115,13 +114,10 @@
             <td v-if="checkAvailability('outputLabel')">            
               <a v-if="canAccessLink(rec, false) && outputReady(rec)"
                 @click="workflowResultService.getSymlinkContent(rec, true, parent, $event)"                
-                target="_blank"
-                class="complete-output"
-                >{{ rec.outputLabel }}
+                target="_blank" class="complete-output">
+                {{ rec.outputLabel }}
               </a>
-              <a v-else-if="canAccessLink(rec, false)"
-                role="link" aria-disabled="true">{{ rec.outputLabel }}
-              </a>         
+              <a v-else-if="canAccessLink(rec, false)" role="link" aria-disabled="true">{{ rec.outputLabel }}</a>         
             <span v-else> {{ rec.outputLabel }} </span>
             </td>
             <td v-if="checkAvailability('groundTruth')">
@@ -130,70 +126,31 @@
             <td v-if="checkAvailability('scores')">
               {{ rec.scores }}
             </td>
-            <td
-              v-if="
-                parent !== 'NewTest' &&
-                  parent !== 'TestResults' &&
-                  checkAvailability('status')
-              "
-            >
-              <button
-                v-if="rec.status === 'COMPLETE'"
-                type="button"
-                class="btn-sm btn btn-success eq-width"
-              >
+            <td v-if="parent !== 'NewTest' && parent !== 'TestResults' && checkAvailability('status')">
+              <button v-if="rec.status === 'COMPLETE'" type="button" class="btn-sm btn btn-success eq-width">
                 Complete
               </button>
-              <button
-                v-else-if="rec.status === 'IN_PROGRESS'"
-                type="button"
-                class="btn-sm btn btn-warning eq-width"
-              >
+              <button v-else-if="rec.status === 'IN_PROGRESS'" type="button" class="btn-sm btn btn-warning eq-width">
                 In Progress
               </button>
-              <button
-                v-else-if="rec.status === 'PAUSED'"
-                type="button"
-                class="btn-sm btn btn-primary eq-width"
-              >
+              <button v-else-if="rec.status === 'PAUSED'" type="button" class="btn-sm btn btn-primary eq-width">
                 Paused
               </button>
-              <button
-                v-else-if="rec.status === 'ERROR'"
-                type="button"
-                class="btn-sm btn btn-danger eq-width"
-              >
+              <button v-else-if="rec.status === 'ERROR'" type="button" class="btn-sm btn btn-danger eq-width">
                 Error
               </button>
-              <button
-                v-else-if="rec.status === 'SCHEDULED'"
-                type="button"
-                class="btn-sm btn btn-blue eq-width"
-              >
+              <button v-else-if="rec.status === 'SCHEDULED'" type="button" class="btn-sm btn btn-blue eq-width">
                 Scheduled
               </button>
-              <button
-                v-else-if="rec.status === 'DELETED'"
-                type="button"
-                class="btn-sm btn eq-width"
-              >
+              <button v-else-if="rec.status === 'DELETED'" type="button" class="btn-sm btn eq-width">
                 Deleted
               </button>
             </td>
             <td
-              v-if="
-                parent !== 'NewTest' &&
-                  parent !== 'TestResults' &&
-                  checkAvailability('actions')
-              "
-              class="toggleActions"
-            >
-              <a
-                class="btn btn-link add-remove to-delete"
-                :class="{
-                  'disabled dis-color': currentUser.username !== rec.submitter,
-                }"
-              >
+              v-if="parent !== 'NewTest' && parent !== 'TestResults' && checkAvailability('actions')"
+              class="toggleActions">
+              <a class="btn btn-link add-remove to-delete"
+                :class="{ 'disabled dis-color': currentUser.username !== rec.submitter }">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="28"
@@ -211,29 +168,18 @@
               </a>
             </td>
             <td
-              v-if="
-                (parent === 'NewTest' || parent === 'TestResults') &&
-                  checkAvailability('addToTest')
-              "
-              class="text-center slim-col-14"
-            >
+              v-if="(parent === 'NewTest' || parent === 'TestResults') && checkAvailability('addToTest')"
+              class="text-center slim-col-14">
               <input
                 class="add-to-test-checkbox"
                 type="checkbox"
                 v-model="mgmEvaluation.selectedRecords"
                 :value="rec"/>
             </td>
-            <td
-              v-if="parent === 'Deliverables' && checkAvailability('isFinal')"
-              class="slim-col-14"
-            >
+            <td v-if="parent === 'Deliverables' && checkAvailability('isFinal')" class="slim-col-14">
               <label class="switch" title="Final Result">
                 <span class="visually-hidden">Final Result</span>
-                <input
-                  type="checkbox"
-                  v-model="rec.isFinal"
-                  v-on:click="setWorkflowResultFinal(rec.id)"
-                />
+                <input type="checkbox" v-model="rec.isFinal" v-on:click="setWorkflowResultFinal(rec.id)"/>
                 <span class="slider round"></span>
               </label>
             </td>
@@ -241,11 +187,7 @@
         </tbody>
         <tbody v-else>
           <tr>
-            <td
-              v-if="workflowDashboard.loading"
-              :colspan="columns.length"
-              class="no-results"
-            >
+            <td v-if="workflowDashboard.loading" :colspan="columns.length" class="no-results">
               <i class="fas fa-cog fa-spin"></i> Loading
             </td>
             <td v-else :colspan="columns.length" class="no-results">


### PR DESCRIPTION
Each filter in the `Dashboard` component have a related variable with its name to maintain values within each filter. When a filter is added this variable gets updated in the `Search` component (which is the modal allowing the selections). 
Then `DashboardTable` component who watches these variables refreshes the data in the table by calling `refreshData()` function. 
And when a filter is removed, `Dashboard` component updates these variables by removing the filter values, which then invokes `refreshData()` function in `DashboardTable` component.

For an example; for `Workflow` filter a variable named `this.workflowDashboard.searchQuery.filterByWorkflows` is maintained across the components. When a filter is selected in the workflows filter modal or removed, `this.workflowDashboard.searchQuery.filterByWorkflows` value gets updated in the `Search` component. And as a result `filterByWorkflows()` in `DashboardTable` component is called to refresh the data in the table.

The code which updates the `this.workflowDashboard.searchQuery.**`style variables for each filter in the `Dashboard` component was not updating them as expected. This code needed to specifically set the `this.workflowDashboard.searchQuery.**` values explicitly when a filter value is removed, which is fixed in this PR.
In addition to the fix, I re-formatted some the HTML template codes for better readability of the code.