### PR TITLE
Remove unsupported API method this. in Vue

### DIFF
--- a/src/components/entity/ItemFiles.vue
+++ b/src/components/entity/ItemFiles.vue
@@ -280,7 +280,7 @@ export default {
         .uploadFile(self.selectedItem.id, formData)
         .then((el) => {
           self.showLoader = false;
-          this.$set(self.primaryFiles._embedded.primaryfiles, index, el.data);
+          self.primaryFiles._embedded.primaryfiles.index = el.data;
         })
         .catch((error) => {
           self.showLoader = false;


### PR DESCRIPTION
Remove unsupported method `this.$set` in Vue 3. Related docs: https://v3-migration.vuejs.org/breaking-changes/#removed-apis