### PR TITLE
AMP-3596: fix search text input on enter key

### DIFF
--- a/src/components/workflow/SelectFiles.vue
+++ b/src/components/workflow/SelectFiles.vue
@@ -14,11 +14,6 @@
       "
     >
       <h2>Select files</h2>
-      <form
-        class="mt-4 filter-form"
-        v-on:submit.prevent
-        v-on:keyup.enter="searchFiles()"
-      >
         <div
           class="container-fluid"
           v-if="
@@ -45,6 +40,7 @@
         <div class="mb-3">
           <!-- Do not perform form validation for partial workflows -->
           <form 
+            @submit.prevent="searchFiles"
             :class="!workflowSubmission.workflowDetails.inputWprkflowResultFormats.length ? 'needs-validation' : ''"
             ref="searchFilesForm"
           >
@@ -89,7 +85,6 @@
           </form>
         </div>
         <div></div>
-      </form>
       <div v-if="workflowSubmissionsearchResults">
         <h4>Search Results</h4>
         <hr class="w-100" />


### PR DESCRIPTION
- fix search text input not responding to enter, by preventing default behavior on its wrapping form
- remove redundant outermost form